### PR TITLE
Edit csproj file

### DIFF
--- a/AsciiArt/AsciiArt.csproj
+++ b/AsciiArt/AsciiArt.csproj
@@ -13,6 +13,8 @@
 	<Nullable>enable</Nullable>
 	<UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
+	<WindowsPackageType>None</WindowsPackageType>
+	<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Edit project file to switch to a non-packaged and self-contained WinUI 3 app by adding:
- ```<WindowsPackageType>```None```</WindowsPackageType>```
- ```<WindowsAppSDKSelfContained>```true```</WindowsAppSDKSelfContained>```

in ```<PropertyGroup>```.